### PR TITLE
Extra field read support added.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 *.pyc
 /dist/
 /*.egg-info
-*.an
-*.po
 *.coverage
 *.ipynb_checkpoints
 .tox
 /htmlcov
 build
+.mypy_cache
+.idea
+.pytest_cache

--- a/moonreader_tools/notes.py
+++ b/moonreader_tools/notes.py
@@ -1,6 +1,19 @@
 """Collection of classes that present different book formats' notes"""
+import datetime
+import enum
+from typing import Tuple
 
-from moonreader_tools.utils import date_from_long_timestamp
+from moonreader_tools.utils import color_tuple_as_hex_code
+
+DEFAULT_COLOR = (0, 255, 255, 255)
+
+
+class NoteStyle(enum.Enum):
+    SELECTED = 'SELECTED'
+    CROSSED_OUT = 'CROSSED_OUT'
+    STRAIGHT_UNDERLINE = 'STRAIGHT_UNDERLINE'
+    WAVEY_UNDERLINE = 'WAVEY_UNDERLINE'
+    DELETED = 'DELETED'
 
 
 class Note(object):
@@ -9,21 +22,44 @@ class Note(object):
     """
     _REPR_TEXT_LENGTH = 100
 
-    def __init__(self, text, timestamp):
+    def __init__(self, text: str, created: datetime.datetime,
+                 style: NoteStyle=NoteStyle.SELECTED,
+                 color: Tuple[int, int, int, int]=DEFAULT_COLOR,
+                 note: str='') -> None:
         self._text = text
-        self._timestamp = timestamp
+        self._created = created
+        self._style = style
+        self._color = color
+        self._note = note
+
+    @property
+    def color(self):
+        return self._color
+
+    @property
+    def style(self):
+        return self._style
 
     @property
     def text(self):
         return self._text
 
-    @text.setter
-    def text(self, new_text):
-        self._text = new_text
+    @property
+    def note(self):
+        return self._note
 
     @property
     def created(self):
-        return date_from_long_timestamp(self._timestamp)
+        return self._created
+
+    def to_dict(self):
+        return {
+            'text': self.text,
+            'note': self.note,
+            'created': self.created.isoformat(),
+            'style': self.style.value,
+            'color': color_tuple_as_hex_code(self.color),
+        }
 
     def __repr__(self):
         return '<Note: {}>'.format(self.text[:self._REPR_TEXT_LENGTH])

--- a/moonreader_tools/parsers/fb2_parser.py
+++ b/moonreader_tools/parsers/fb2_parser.py
@@ -2,10 +2,10 @@ from typing import List
 
 from moonreader_tools.accessors.file_reader import FileReader
 from moonreader_tools.notes import Note
-from moonreader_tools.utils import one_obj_or_list
+from moonreader_tools.parsers.note_extractor import NoteExtractorMixin
 
 
-class FB2NoteParser(FileReader):
+class FB2NoteParser(FileReader, NoteExtractorMixin):
     # TODO: Inherit from the base class
     """Parser for FB2 book format"""
 
@@ -26,10 +26,10 @@ class FB2NoteParser(FileReader):
         (7, 1, 'highlight_length'),
         (8, 1, "color"),  # number, that shows the color styling has
         (9, 1, "timestamp"),  # integer, that shows when note was made
-        (10, 2, "separator_space"),
+        (10, 1, "separator_space"),
         (11, 1, "note"),
         (12, 1, 'text'),  # actually, note's text
-        (13, 3, 'modifier_bits'),  # is note deleted, e.g.
+        (13, 3, 'style'),  # is note deleted, e.g.
     ]
 
     @classmethod
@@ -61,10 +61,7 @@ class FB2NoteParser(FileReader):
         book_dict = {}
         for item in cls.NOTE_SCHEME:
             book_dict[item[cls.NAME]] = cls._extract_note_part(item, str_list)
-        return Note(
-            text=one_obj_or_list(book_dict['text']),
-            timestamp=one_obj_or_list(book_dict['timestamp'])
-        )
+        return cls.note_from_dictionary(book_dict)
 
     @classmethod
     def _extract_note_part(cls, item_part, token_list):

--- a/moonreader_tools/parsers/note_extractor.py
+++ b/moonreader_tools/parsers/note_extractor.py
@@ -1,0 +1,52 @@
+import datetime
+from typing import Tuple
+
+from moonreader_tools import utils
+from moonreader_tools.notes import Note, NoteStyle
+
+
+DELETED_MARKER = '*DELETED*'
+
+
+class NoteExtractorMixin(object):
+
+    REQUIRED_FIELDS = {'text', 'color', 'timestamp', 'style'}
+
+    @staticmethod
+    def extract_text(note_dict: dict) -> str:
+        return utils.one_obj_or_list(note_dict['text'])
+
+    @staticmethod
+    def extract_color(note_dict: dict) -> Tuple[int, int, int, int]:
+        color = int(utils.one_obj_or_list(note_dict['color']))
+        return utils.color_tuple_from_overflowed_integer(color)
+
+    @staticmethod
+    def extract_created(note_dict: dict) -> datetime.datetime:
+        timestamp = utils.one_obj_or_list(note_dict['timestamp'])
+        return utils.date_from_long_timestamp(timestamp)
+
+    @staticmethod
+    def extract_style(note_dict):
+        style = note_dict['style']
+        if isinstance(style, list):
+            if style[-1] == DELETED_MARKER:
+                return NoteStyle.DELETED
+        # FIXME: handle all of the other cases!
+        # I don't have examples of other styles/modifiers applied
+        # Perhaps I need to create a set of fake PDF books and
+        # experiment with it later
+        return NoteStyle.SELECTED
+
+    @classmethod
+    def note_from_dictionary(cls, note_dict: dict) -> Note:
+        assert cls.REQUIRED_FIELDS < note_dict.keys(), \
+            'Some of the required keys for the note are missing: ' + \
+            str(cls.REQUIRED_FIELDS - note_dict.keys())
+
+        return Note(
+            text=cls.extract_text(note_dict),
+            created=cls.extract_created(note_dict),
+            color=cls.extract_color(note_dict),
+            style=cls.extract_style(note_dict),
+        )

--- a/moonreader_tools/parsers/pdf_parser.py
+++ b/moonreader_tools/parsers/pdf_parser.py
@@ -2,9 +2,10 @@ import re
 
 from moonreader_tools.accessors.file_reader import FileReader
 from moonreader_tools.notes import Note
+from moonreader_tools.parsers.note_extractor import NoteExtractorMixin
 
 
-class PDFNoteParser(FileReader):
+class PDFNoteParser(FileReader, NoteExtractorMixin):
     # TODO: inherit from the basic object
     """Reads notes from PDF flike object"""
     NOTE_START = "#A*#"
@@ -16,8 +17,8 @@ class PDFNoteParser(FileReader):
         (0, 'unknown_1'),
         (1, "page"),
         (2, "timestamp"),
-        (3, 'unknown_2'),
-        (4, 'unknown_3'),
+        (3, 'unknown_2'),  # Highlight start index?
+        (4, 'unknown_3'),  # Highlight end index?
         (5, "color"),
         (6, "style"),
         (7, "note"),
@@ -63,10 +64,7 @@ class PDFNoteParser(FileReader):
     def single_note_from_text(cls, text) -> Note:
         """Create note from text"""
         token_dict = cls._dict_from_text(text)
-        return Note(
-            text=token_dict.get("text", ""),
-            timestamp=token_dict.get("timestamp")
-        )
+        return cls.note_from_dictionary(token_dict)
 
     @classmethod
     def _dict_from_text(cls, text):

--- a/moonreader_tools/stat.py
+++ b/moonreader_tools/stat.py
@@ -24,6 +24,12 @@ class Statistics(object):
     def __str__(self) -> str:
         return self.__repr__()
 
+    def to_dict(self):
+        return {
+            'percentage': self.percentage,
+            'pages': self.pages,
+        }
+
     @classmethod
     def empty_stats(cls):
         """Returns empty statistics object."""

--- a/moonreader_tools/utils.py
+++ b/moonreader_tools/utils.py
@@ -4,7 +4,8 @@ Module contains helper functions used across the library
 
 import os
 import datetime
-
+import struct
+from typing import Tuple
 
 from .conf import ALLOWED_TYPES, NOTE_EXTENSION, STAT_EXTENSION
 from .errors import BookTypeError
@@ -98,10 +99,31 @@ def get_moonreader_files_from_filelist(file_list):
             if f.endswith((NOTE_EXTENSION, STAT_EXTENSION)))
 
 
-def date_from_long_timestamp(str_timestamp):
+def date_from_long_timestamp(str_timestamp: str) -> datetime.datetime:
     """Moonreader files utilize awkward timestamp version,
     so we trim it and calculate date"""
     return datetime.datetime.fromtimestamp(float(str_timestamp[:10]))
+
+
+def color_tuple_from_overflowed_integer(number: int) -> Tuple[int, int, int, int]:
+    """
+    Internally we get the color stored as the overflowed
+    signed integer, so we put it back into
+    bytes representantion and extract color bytes
+    (Opacity, Red, Green, Blue)
+    """
+    return struct.unpack('BBBB', struct.pack('i', number))  # type: ignore
+
+
+def color_tuple_as_hex_code(color_tuple: Tuple[int, int, int, int]) -> str:
+    """
+    >>> color_tuple_as_hex_code((0, 255, 0, 255))
+    >>> "#FF00FF"
+    """
+    return "#" + "".join(
+        hex(byte_as_int).replace('0x', '')
+        for byte_as_int in color_tuple[-3:]
+    )
 
 
 def get_same_book_files(files):

--- a/tests/dto/test_note.py
+++ b/tests/dto/test_note.py
@@ -1,0 +1,14 @@
+import datetime
+
+from moonreader_tools.notes import Note, NoteStyle
+
+
+def test_valid_defaults_for_note():
+    name, now, note = 'text', datetime.datetime.utcnow(), 'Some remark'
+    n = Note(text='text', created=now, note=note)
+
+    assert n.text == name
+    assert n.created == now
+    assert n.style == NoteStyle.SELECTED
+    assert n.color == (0, 255, 255, 255)
+    assert n.note == note


### PR DESCRIPTION
It is now possible to properly access "note", "style", and "color" note
fields.

Book serialization to dictionary fixed.

Note: https://github.com/MrLokans/MoonReader_tools/issues/9 should be fixed after merging this PR and uploading the package to PyPI